### PR TITLE
Add 'scenes' metadata with image analysis UI and backend support

### DIFF
--- a/web/app.css
+++ b/web/app.css
@@ -883,6 +883,55 @@ h2 {
     color: var(--gold-dim);
 }
 
+
+.analysis-result {
+    background: linear-gradient(145deg, rgba(212, 180, 110, 0.12), rgba(212, 180, 110, 0.03));
+    border: 1px solid rgba(212, 180, 110, 0.35);
+    border-radius: 8px;
+    padding: 12px;
+}
+
+.analysis-result-head {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.analysis-result-title {
+    color: var(--gold-primary);
+    font-size: 0.8rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.analysis-result-subtitle {
+    color: var(--text-muted);
+    font-size: 0.78rem;
+}
+
+.scene-tag {
+    color: var(--gold-primary);
+    border-color: rgba(212, 180, 110, 0.45);
+}
+
+.scene-tag-btn {
+    cursor: pointer;
+    transition: all 0.2s ease;
+    font-family: inherit;
+}
+
+.scene-tag-btn:hover {
+    transform: translateY(-1px);
+    border-color: rgba(212, 180, 110, 0.65);
+}
+
+.scene-tag-btn.active {
+    background: rgba(212, 180, 110, 0.24);
+    color: #f8e3ae;
+    border-color: rgba(212, 180, 110, 0.85);
+    box-shadow: 0 0 0 1px rgba(212, 180, 110, 0.2) inset;
+}
+
 .modal-actions {
     display: flex;
     gap: 12px;
@@ -2255,4 +2304,13 @@ select.codex-input {
     .codex-header {
         padding: 12px 16px;
     }
+}
+
+[data-theme="light"] .analysis-result {
+    background: linear-gradient(145deg, rgba(212, 180, 110, 0.18), rgba(255, 255, 255, 0.75));
+    border-color: rgba(139, 105, 20, 0.35);
+}
+
+[data-theme="light"] .scene-tag-btn.active {
+    color: #6a4c00;
 }

--- a/web/app.js
+++ b/web/app.js
@@ -18,7 +18,7 @@ createApp({
         const previewOpen = ref(false);
         const previewItem = ref(null);
         const isEditing = ref(false);
-        const editForm = reactive({ category: '', tags: '', desc: '' });
+        const editForm = reactive({ category: '', tags: '', scene: '', desc: '' });
 
         // Batch Mode
         const isBatchMode = ref(false);
@@ -32,8 +32,36 @@ createApp({
         const uploadFile = ref(null);
         const uploadPreviewUrl = ref(null);
         const uploadError = ref(null);
-        const uploadForm = reactive({ emotion: '', tags: '', desc: '' });
+        const uploadForm = reactive({ emotion: '', tags: '', scene: '', desc: '' });
         const availableEmotions = ref([]);
+        const analysisScenes = ref([]);
+
+
+        const parseSceneList = (rawText) => {
+            if (!rawText) return [];
+            const seen = new Set();
+            return String(rawText)
+                .split(/[，,、;；\n\t]+/)
+                .map((item) => item.trim())
+                .filter((item) => {
+                    if (!item || seen.has(item)) return false;
+                    seen.add(item);
+                    return true;
+                });
+        };
+
+        const toggleScene = (scene) => {
+            const sceneList = parseSceneList(uploadForm.scene);
+            if (sceneList.includes(scene)) {
+                uploadForm.scene = sceneList.filter((item) => item !== scene).join('、');
+                return;
+            }
+            uploadForm.scene = [...sceneList, scene].join('、');
+        };
+
+        const isSceneSelected = (scene) => parseSceneList(uploadForm.scene).includes(scene);
+
+        // Upload Helpers
 
         // Category Management
         const emotionsOpen = ref(false);
@@ -238,7 +266,8 @@ createApp({
             if (!previewItem.value) return;
             Object.assign(editForm, {
                 category: previewItem.value.category,
-                tags: previewItem.value.tags.join(', '),
+                tags: (previewItem.value.tags || []).join(', '),
+                scene: (previewItem.value.scenes || []).join('、'),
                 desc: previewItem.value.desc,
             });
             isEditing.value = true;
@@ -261,6 +290,7 @@ createApp({
                     isEditing.value = false;
                     previewItem.value.category = editForm.category;
                     previewItem.value.tags = editForm.tags.split(',').map((t) => t.trim()).filter((t) => t);
+                    previewItem.value.scenes = parseSceneList(editForm.scene);
                     previewItem.value.desc = editForm.desc;
                     fetchImages(currentPage.value);
                 } else {
@@ -379,12 +409,14 @@ createApp({
             uploadFile.value = null;
             uploadPreviewUrl.value = null;
             uploadError.value = null;
-            Object.assign(uploadForm, { emotion: '', tags: '', desc: '' });
+            Object.assign(uploadForm, { emotion: '', tags: '', scene: '', desc: '' });
+            analysisScenes.value = [];
             fetchEmotions();
         };
 
         const closeUploadModal = () => {
             uploadOpen.value = false;
+            analysisScenes.value = [];
         };
 
         const handleFileSelect = (e) => {
@@ -393,6 +425,8 @@ createApp({
                 uploadFile.value = file;
                 uploadPreviewUrl.value = URL.createObjectURL(file);
                 uploadError.value = null;
+                uploadForm.scene = '';
+                analysisScenes.value = [];
             }
         };
 
@@ -404,6 +438,7 @@ createApp({
                 formData.append('file', uploadFile.value);
                 formData.append('emotion', uploadForm.emotion);
                 formData.append('tags', uploadForm.tags);
+                formData.append('scene', uploadForm.scene);
                 formData.append('desc', uploadForm.desc);
 
                 const res = await apiFetch('api/images/upload', { method: 'POST', body: formData });
@@ -440,7 +475,7 @@ createApp({
             /**
              * 分析图片
              * @param {File} file - 图片文件
-             * @returns {Promise<{category, tags, description}>} 分析结果
+             * @returns {Promise<{category, tags, scenes, description}>} 分析结果
              */
             const analyze = async (file) => {
                 if (!file) {
@@ -516,6 +551,12 @@ createApp({
                     }
                 }
                 
+                // 填充场景
+                if (Array.isArray(data.scenes) && data.scenes.length > 0) {
+                    form.scene = parseSceneList(data.scenes.join('、')).join('、');
+                    result.fields.push('scenes');
+                }
+
                 // 填充描述（仅在空时填充）
                 if (data.description && !form.desc) {
                     form.desc = data.description;
@@ -545,6 +586,7 @@ createApp({
             
             try {
                 const data = await imageAnalyzer.analyze(uploadFile.value);
+                analysisScenes.value = Array.isArray(data.scenes) ? data.scenes : [];
                 const result = imageAnalyzer.applyToForm(data, uploadForm, availableEmotions.value);
                 
                 if (!result.filled) {
@@ -735,6 +777,9 @@ createApp({
             uploadError,
             uploadForm,
             availableEmotions,
+            analysisScenes,
+            isSceneSelected,
+            toggleScene,
             openUploadModal,
             closeUploadModal,
             handleFileSelect,

--- a/web/index.html
+++ b/web/index.html
@@ -410,6 +410,16 @@
                                     </span>
                                     <span v-if="!(previewItem?.tags || []).length" style="font-size: 0.85rem; color: var(--text-muted);">无标签</span>
                                 </div>
+
+                                <div class="stat-row">
+                                    <span class="stat-name">场景</span>
+                                </div>
+                                <div class="item-tags" style="margin-bottom: 12px;">
+                                    <span v-for="scene in (previewItem?.scenes || [])" :key="scene" class="tag scene-tag">
+                                        {{ scene }}
+                                    </span>
+                                    <span v-if="!(previewItem?.scenes || []).length" style="font-size: 0.85rem; color: var(--text-muted);">无场景</span>
+                                </div>
                                 
                                 <div class="stat-row">
                                     <span class="stat-name">添加时间</span>
@@ -438,6 +448,11 @@
                                     <textarea v-model="editForm.desc" class="codex-input" rows="3"></textarea>
                                 </div>
                                 
+                                <div style="margin-bottom: 20px;">
+                                    <label style="font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-muted); display: block; margin-bottom: 8px;">场景 (顿号/逗号分隔)</label>
+                                    <input v-model="editForm.scene" type="text" class="codex-input" placeholder="例如: 庆祝、表达开心">
+                                </div>
+
                                 <div style="margin-bottom: 20px;">
                                     <label style="font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-muted); display: block; margin-bottom: 8px;">标签 (逗号分隔)</label>
                                     <input v-model="editForm.tags" type="text" class="codex-input" placeholder="例如: 可爱, 搞怪, 稀有">
@@ -550,6 +565,31 @@
                             </select>
                         </div>
                         
+                        <div v-if="analysisScenes.length" class="analysis-result" style="margin-top: 16px;">
+                            <div class="analysis-result-head">
+                                <div class="analysis-result-title">识别到的场景</div>
+                                <div class="analysis-result-subtitle">点击标签可添加/移除到“场景”输入框</div>
+                            </div>
+                            <div class="item-tags" style="margin-top: 10px;">
+                                <button
+                                    v-for="scene in analysisScenes"
+                                    :key="scene"
+                                    type="button"
+                                    class="tag scene-tag scene-tag-btn"
+                                    :class="{ active: isSceneSelected(scene) }"
+                                    @click="toggleScene(scene)"
+                                >
+                                    {{ scene }}
+                                </button>
+                            </div>
+                        </div>
+
+                        <div style="margin-top: 16px;">
+                            <label style="font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-muted); display: block; margin-bottom: 8px;">场景</label>
+                            <input v-model="uploadForm.scene" type="text" class="codex-input" placeholder="例如: 办公室、聊天窗口、深夜">
+                            <p style="margin: 8px 0 0; font-size: 0.8rem; color: var(--text-muted);">支持使用中文顿号、逗号或分号分隔。</p>
+                        </div>
+
                         <div style="margin-top: 16px;">
                             <label style="font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.1em; color: var(--text-muted); display: block; margin-bottom: 8px;">标签</label>
                             <input v-model="uploadForm.tags" type="text" class="codex-input" placeholder="例如: 可爱, 搞怪">

--- a/web_server.py
+++ b/web_server.py
@@ -192,6 +192,25 @@ class WebServer:
     def _split_csv_tags(tags_raw: str) -> list[str]:
         return [t.strip() for t in str(tags_raw).split(",") if t.strip()]
 
+    @staticmethod
+    def _split_scene_terms(scene_raw: Any) -> list[str]:
+        if scene_raw is None:
+            return []
+        if isinstance(scene_raw, list):
+            raw_items = scene_raw
+        else:
+            raw_items = str(scene_raw).replace("、", ",").replace("，", ",").replace("；", ",").split(",")
+
+        seen: set[str] = set()
+        scenes: list[str] = []
+        for item in raw_items:
+            text = str(item).strip()
+            if not text or text in seen:
+                continue
+            seen.add(text)
+            scenes.append(text)
+        return scenes
+
     async def _collect_removed_paths_by_hashes(self, hashes: set[str]) -> list[str]:
         removed_paths: list[str] = []
         await self.plugin.cache_service.update_index(
@@ -627,6 +646,7 @@ class WebServer:
                         "category": meta.get("category", "unknown"),
                         "tags": meta.get("tags", []),
                         "desc": meta.get("desc", ""),
+                        "scenes": self._split_scene_terms(meta.get("scenes", [])),
                         "created_at": meta.get("created_at", 0),
                     }
 
@@ -647,8 +667,9 @@ class WebServer:
                             pass
 
                     if search_query and not (
-                        any(search_query in t.lower() for t in item["tags"])
+                        any(search_query in str(t).lower() for t in item["tags"])
                         or search_query in item["desc"].lower()
+                        or any(search_query in str(scene).lower() for scene in item.get("scenes", []))
                     ):
                         continue
 
@@ -782,7 +803,7 @@ class WebServer:
         return moved_count, moved_hashes
 
     async def handle_update_image(self, request):
-        """更新图片信息 (Category, Tags, Desc)"""
+        """更新图片信息 (Category, Tags, Desc, Scenes)"""
         try:
             image_hash = request.match_info["hash"]
             data = await self._read_json_payload(request)
@@ -790,6 +811,7 @@ class WebServer:
             new_category = data.get("category")
             new_tags = data.get("tags")  # list or comma separated string
             new_desc = data.get("desc")
+            new_scenes = data.get("scenes", data.get("scene"))
 
             updated = {"ok": False, "error": ""}
 
@@ -814,6 +836,9 @@ class WebServer:
 
                 if new_desc is not None:
                     meta["desc"] = new_desc
+
+                if new_scenes is not None:
+                    meta["scenes"] = self._split_scene_terms(new_scenes)
 
                 if new_category and new_category != meta.get("category"):
                     old_path = Path(target_path)
@@ -983,6 +1008,7 @@ class WebServer:
             tags_raw = data.get("tags", "").strip()
             tags = self._split_csv_tags(tags_raw) if tags_raw else []
             desc = data.get("desc", "").strip()
+            scenes = self._split_scene_terms(data.get("scene", ""))
 
             file_ext = Path(uploaded_file.filename).suffix.lower()
             allowed_exts = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp"}
@@ -1015,6 +1041,7 @@ class WebServer:
                         "category": category,
                         "tags": tags,
                         "desc": desc,
+                        "scenes": scenes,
                         "created_at": timestamp,
                     },
                 )
@@ -1029,6 +1056,7 @@ class WebServer:
                         "category": category,
                         "tags": tags,
                         "desc": desc,
+                        "scenes": scenes,
                         "created_at": timestamp,
                     },
                 }
@@ -1200,6 +1228,7 @@ class WebServer:
                     "category": category,
                     "tags": tags,
                     "description": desc,
+                    "scenes": scenes or [],
                 })
 
             finally:


### PR DESCRIPTION
### Motivation
- Enable capturing and editing image "scenes" metadata provided by the visual analyzer so users can tag contextual scene information for images. 
- Present analyzer-suggested scenes in the upload UI and allow quick toggling to populate the `scene` input. 
- Persist scenes on the server, include them in listing/searching, and allow updating via the image update API. 

### Description
- Frontend: added CSS for analysis UI (`.analysis-result`, `.scene-tag`, `.scene-tag-btn`) and integrated `scene` into reactive forms `uploadForm` and `editForm`. 
- Frontend: implemented `parseSceneList`, `toggleScene`, and `isSceneSelected` helpers, exposed `analysisScenes`, and updated `useImageAnalyzer` and `analyzeImage` to accept and apply `scenes` from analyzer results to the form. 
- Frontend: updated `index.html` to show detected scenes in the upload modal with clickable buttons, added scene display and edit input in the preview/edit panes, and wired scene submission in `submitUpload`. 
- Backend: added `_split_scene_terms` for robust scene parsing, included `scenes` in image index items and API responses, added scene-aware search matching, persisted scenes during upload in `handle_upload_image`, and accepted scene updates in `handle_update_image`; the analyzer endpoint now returns `scenes` from `image_processor.classify_image`. 

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ad93003ce4832692f384d7cf669b42)