### PR TITLE
fix: WebUI 单张上传使用 base64 JSON 绕过 sandbox 限制

### DIFF
--- a/pages/表情管理/app.js
+++ b/pages/表情管理/app.js
@@ -1730,17 +1730,29 @@ body: JSON.stringify({ hashes: Array.from(selectedImages.value), favorite }),
             if (!uploadFile.value) return;
             uploading.value = true;
             try {
-                const uploadRes = await bridge.upload('images/upload', uploadFile.value);
-                if (!uploadRes.success || !uploadRes.hash) {
-                    uploadError.value = uploadRes.error || '上传失败';
+                // Use base64 JSON to avoid ERR_ACCESS_DENIED from bridge.upload()
+                const base64Data = await fileToBase64(uploadFile.value);
+                const uploadRes = await apiFetch('api/images/upload', {
+                    method: 'POST',
+                    body: JSON.stringify({
+                        base64: base64Data,
+                        filename: uploadFile.value.name,
+                    }),
+                });
+                const uploadData = await uploadRes.json();
+                if (!uploadData.success || !uploadData.hash) {
+                    uploadError.value = uploadData.error || '上传失败';
                     return;
                 }
-                await bridge.apiPost('images/update', {
-                    hash: uploadRes.hash,
-                    category: uploadForm.emotion,
-                    tags: uploadForm.tags,
-                    scene: uploadForm.scene,
-                    desc: uploadForm.desc,
+                await apiFetch('api/images/update', {
+                    method: 'POST',
+                    body: JSON.stringify({
+                        hash: uploadData.hash,
+                        category: uploadForm.emotion,
+                        tags: uploadForm.tags,
+                        scene: uploadForm.scene,
+                        desc: uploadForm.desc,
+                    }),
                 });
                 closeUploadModal();
                 fetchImages(1);

--- a/plugin_api.py
+++ b/plugin_api.py
@@ -567,15 +567,32 @@ class PluginAPI:
     async def handle_upload_image(self):
         try:
             files = await request.files
-            if "file" not in files:
-                return jsonify({"success": False, "error": "没有上传文件"})
-            f = files["file"]
-            ext = Path(f.filename or "upload.png").suffix.lower()
+            file_content = None
+            file_ext = ".png"
+            filename = "upload.png"
+
+            if "file" in files:
+                f = files["file"]
+                file_content = f.read()
+                filename = f.filename or "upload.png"
+            else:
+                data = await request.get_json() or {}
+                b64 = data.get("base64", "")
+                if not b64:
+                    return jsonify({"success": False, "error": "没有上传文件"})
+                if "," in b64:
+                    b64 = b64.split(",")[1]
+                file_content = base64.b64decode(b64)
+                filename = data.get("filename", "upload.png")
+
+            ext = Path(filename).suffix.lower()
             if not self._is_allowed_ext(ext):
                 return jsonify({"success": False, "error": f"不支持的文件类型: {ext}"})
-            content = f.read()
+            if not file_content:
+                return jsonify({"success": False, "error": "文件内容为空"})
+
             image = await self._persist_image(
-                file_content=content, file_ext=ext, category="unknown"
+                file_content=file_content, file_ext=ext, category="unknown"
             )
             if not self._db:
                 await self._sync_index()


### PR DESCRIPTION
AstrBot 插件页面运行在 sandbox iframe 中，bridge.upload() 发送 multipart/form-data 被浏览器拦截（ERR_ACCESS_DENIED）。

改为使用 base64 编码后通过 bridge.apiPost() 发送 JSON 请求，
与批量上传采用相同的方案。后端 handle_upload_image 同时兼容
 multipart/form-data 和 JSON base64 两种方式。