### PR TITLE
feat(qq): aiocqhttp 平台发送表情时外显改为 [动画表情]

### DIFF
--- a/core/events/emoji_sender_engine.py
+++ b/core/events/emoji_sender_engine.py
@@ -1,13 +1,43 @@
 """表情包发送决策引擎：负责 LLM 响应拦截、自动发送决策和表情包发送。"""
 
 import asyncio
+import os
 import random
 import re
 from typing import Any
 
+from astrbot.api.message_components import Image
+from astrbot.core.message.message_event_result import MessageChain
+
 from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent
 from astrbot.api.message_components import Plain
+
+
+async def _send_qq_image_as_sticker(
+    event: AstrMessageEvent,
+    file_path: str,
+    summary: str = "[动画表情]",
+) -> bool:
+    """在 QQ (aiocqhttp) 平台发送表情包时修改 summary 外显。"""
+    try:
+        from astrbot.core.platform.sources.aiocqhttp.aiocqhttp_message_event import (
+            AiocqhttpMessageEvent,
+        )
+    except ImportError:
+        return False
+    if not isinstance(event, AiocqhttpMessageEvent):
+        return False
+    if not file_path or not os.path.exists(file_path):
+        return False
+    try:
+        chain = MessageChain(chain=[Image(file=file_path)])
+        obmsg = await event._parse_onebot_json(chain)
+        obmsg[0]["data"]["summary"] = summary
+        await event.bot.send(event.message_obj.raw_message, obmsg)
+        return True
+    except Exception:
+        return False
 
 
 class _EmojiTurnState:
@@ -315,15 +345,14 @@ class EmojiSenderEngine:
         self, event: AstrMessageEvent, emoji_paths: list[str], cleaned_text: str
     ) -> bool:
         """发送指定的表情包。"""
-        from astrbot.api.message_components import Image
-
         if not emoji_paths:
             return False
 
         sent = False
         for path in emoji_paths:
             try:
-                await event.send(Image(file=path))
+                if not await _send_qq_image_as_sticker(event, path):
+                    await event.send(Image(file=path))
                 sent = True
             except Exception as e:
                 logger.warning(f"[EmojiSenderEngine] 发送表情包失败: {e}")

--- a/core/search/emoji_smart_select_service.py
+++ b/core/search/emoji_smart_select_service.py
@@ -8,6 +8,8 @@ from astrbot.api import logger
 from astrbot.api.event import AstrMessageEvent
 from astrbot.core.agent.run_context import ContextWrapper
 
+from ..events.emoji_sender_engine import _send_qq_image_as_sticker
+
 from .text_similarity import calculate_hybrid_similarity, calculate_simple_similarity, tokenize_for_bm25, _extract_words
 from .embedding_service import EmbeddingService
 
@@ -631,6 +633,9 @@ class EmojiSmartSelectService:
         event = _unwrap_event(event)
         if await self._try_send_telegram_sticker(event, emoji_path):
             return "telegram_sticker"
+
+        if await _send_qq_image_as_sticker(event, emoji_path):
+            return "qq_sticker"
 
         if await self._send_emoji_file_directly(event, emoji_path):
             return "file_image"


### PR DESCRIPTION
## 变更说明

在 aiocqhttp 平台发送表情包时，通过修改 OneBot JSON 的 `summary` 字段，使图片外显从默认的 `[图片]` 改为 `[动画表情]`，模拟真实 QQ 表情包效果。

## 修改文件

- **`core/events/emoji_sender_engine.py`**：新增 `_send_qq_image_as_sticker()` 工具函数，并在 `send_explicit_emojis()` 中优先调用；文件顶部补充必要导入
- **`core/search/emoji_smart_select_service.py`**：在 `send_emoji_message()` 的发送链路中插入 QQ 表情包发送路径作为第二优先级（Telegram 贴纸之后，文件直发之前）

## 实现细节

- 惰性导入 `AiocqhttpMessageEvent`，非 aiocqhttp 平台自动跳过
- `isinstance(event, AiocqhttpMessageEvent)` 校验 + try/except 兜底，失败回退到原发送逻辑
- 非 QQ 平台或非文件路径等边缘情况均被覆盖，不影响原有行为

## 验证

- 编译通过（`py_compile`）
- QQ 平台发送表情后外显为 `[动画表情]` 而非 `[图片]`

Closes #80 