### PR TITLE
fix(qq): send_meme_as_gif 失效修复；新增 按字延迟 与空回复保护

### DIFF
--- a/_conf_schema.json
+++ b/_conf_schema.json
@@ -94,8 +94,19 @@
     "default": false,
     "hint": "✅ 开启：以 GIF 输出（更接近真表情包样式）\n❌ 关闭：按原文件格式发送（png/jpg/gif 等）\n\n⚠️ 开启后高频发送大图/动图场景会有较高瞬时内存占用"
   },
+  "meme_send_char_delay": {
+    "description": "表情包发送按字延迟/秒",
+    "type": "float",
+    "default": 0.3,
+    "slider": {
+      "min": 0.0,
+      "max": 2.0,
+      "step": 0.05
+    },
+    "hint": "按 LLM 回复文本的字数计算延迟（秒/字），设为 0 则使用下方固定与随机延迟配置"
+  },
   "meme_send_delay": {
-    "description": "表情包发送延迟/秒",
+    "description": "表情包发送固定延迟/秒",
     "type": "float",
     "default": 5.0,
     "hint": "等待此时间后发送表情包，避免与分段插件冲突\n建议 5.0 秒以上，让分段先发完\n设为 0 则立即发送"

--- a/core/config/config.py
+++ b/core/config/config.py
@@ -17,6 +17,7 @@ class PluginConfig(BaseModel):
     auto_send_meme: bool = False
     meme_chance: float = 0.2
     send_meme_as_gif: bool = False
+    meme_send_char_delay: float = 0.3
     meme_send_delay: float = 5.0
     meme_send_delay_random: bool = False
     meme_send_delay_max: float = 8.0

--- a/core/events/emoji_sender_engine.py
+++ b/core/events/emoji_sender_engine.py
@@ -18,6 +18,7 @@ async def _send_qq_image_as_sticker(
     event: AstrMessageEvent,
     file_path: str,
     summary: str = "[动画表情]",
+    plugin: Any = None,
 ) -> bool:
     """在 QQ (aiocqhttp) 平台发送表情包时修改 summary 外显。"""
     try:
@@ -31,7 +32,14 @@ async def _send_qq_image_as_sticker(
     if not file_path or not os.path.exists(file_path):
         return False
     try:
-        chain = MessageChain(chain=[Image(file=file_path)])
+        file_source: str = file_path
+        if plugin and getattr(plugin, "send_meme_as_gif", False):
+            image_processor = getattr(plugin, "image_processor_service", None)
+            if image_processor:
+                b64 = await image_processor._file_to_gif_base64(file_path)
+                if b64:
+                    file_source = f"base64://{b64}"
+        chain = MessageChain(chain=[Image(file=file_source)])
         obmsg = await event._parse_onebot_json(chain)
         obmsg[0]["data"]["summary"] = summary
         await event.bot.send(event.message_obj.raw_message, obmsg)
@@ -351,15 +359,22 @@ class EmojiSenderEngine:
         sent = False
         for path in emoji_paths:
             try:
-                if not await _send_qq_image_as_sticker(event, path):
+                if not await _send_qq_image_as_sticker(event, path, plugin=self.plugin):
                     await event.send(Image(file=path))
                 sent = True
             except Exception as e:
                 logger.warning(f"[EmojiSenderEngine] 发送表情包失败: {e}")
         return sent
 
-    def get_meme_send_delay(self) -> float:
+    def get_meme_send_delay(self, text: str = "", task_start: float = 0.0) -> float:
         """获取表情包发送延迟（秒）。"""
+        char_delay = getattr(self.plugin, "meme_send_char_delay", 0.0)
+        if char_delay > 0 and text:
+            desired = len(text) * char_delay
+            if task_start > 0:
+                elapsed = asyncio.get_event_loop().time() - task_start
+                return max(0.0, desired - elapsed)
+            return desired
         delay = getattr(self.plugin, "meme_send_delay", 0.5)
         delay_random = getattr(self.plugin, "meme_send_delay_random", 0.0)
         try:
@@ -389,6 +404,7 @@ class EmojiSenderEngine:
         本方法成功发送后再标记 mark_active_sent 以记录实际发送时间。
         """
         try:
+            task_start = asyncio.get_event_loop().time()
             final_emotions = list(emotions or [])
 
             if getattr(self.plugin, "enable_natural_emotion_analysis", False) and hasattr(
@@ -406,7 +422,12 @@ class EmojiSenderEngine:
             if not final_emotions:
                 return
 
-            delay = self.get_meme_send_delay()
+            result = event.get_result()
+            if result and not result.get_plain_text().strip():
+                logger.debug("[EmojiSenderEngine] 主回复已被置空，跳过自动表情")
+                return
+
+            delay = self.get_meme_send_delay(text, task_start)
             if delay > 0:
                 await asyncio.sleep(delay)
 

--- a/core/search/emoji_smart_select_service.py
+++ b/core/search/emoji_smart_select_service.py
@@ -634,7 +634,7 @@ class EmojiSmartSelectService:
         if await self._try_send_telegram_sticker(event, emoji_path):
             return "telegram_sticker"
 
-        if await _send_qq_image_as_sticker(event, emoji_path):
+        if await _send_qq_image_as_sticker(event, emoji_path, plugin=self.plugin):
             return "qq_sticker"
 
         if await self._send_emoji_file_directly(event, emoji_path):

--- a/main.py
+++ b/main.py
@@ -112,6 +112,7 @@ class Main(Star):
         self.meme_send_delay = self.plugin_config.meme_send_delay
         self.meme_send_delay_random = self.plugin_config.meme_send_delay_random
         self.meme_send_delay_max = self.plugin_config.meme_send_delay_max
+        self.meme_send_char_delay = self.plugin_config.meme_send_char_delay
         self.max_reg_num = self.plugin_config.max_reg_num
         self.content_filtration = self.plugin_config.content_filtration
         self.content_filtration_fail_open = self.plugin_config.content_filtration_fail_open


### PR DESCRIPTION
修复 `send_meme_as_gif` 开启时 QQ sticker 路径未执行 GIF 转换的问题；新增按字延迟与空回复跳过保护。

### 1. 修复 `send_meme_as_gif` 对 QQ sticker 不生效

之前 `_send_qq_image_as_sticker` 直接传原始 `file_path` 构造 Image 段，`send_meme_as_gif=True` 时 QQ 平台绕过了 GIF 转换逻辑。改为检测 `plugin.send_meme_as_gif` 后调用 `_file_to_gif_base64()` 再以 `base64://` 发送。

- `_send_qq_image_as_sticker` 新增 `plugin: Any = None` 参数
- 调用方（`send_explicit_emojis`、`emoji_smart_select_service`）传入 `plugin=self.plugin`

### 2. 新增 `meme_send_char_delay` 按字延迟配置

让发送延迟与 LLM 回复长度成正比，默认 0.3s/字，提供更可控合理的延迟设置，设为 0 回退原有固定/随机延迟。

- `_conf_schema.json`：新增滑块（0~2.0，step 0.05，default 0.3）
- `core/config/config.py`：新增字段 `meme_send_char_delay: float = 0.3`
- `main.py`：`_sync_all_config()` 同步
- `get_meme_send_delay(text)` 增加 `text` 参数，`char_delay > 0 and text` 时返回 `len(text) * char_delay`
- `async_analyze_and_send_emoji` 传入 `cleaned_text`

### 3. LLM 回复置空时跳过自动表情

- `async_analyze_and_send_emoji` 中新增守卫：`event.get_result().get_plain_text().strip()` 为空时跳过发送

### 4. `meme_send_delay` 描述区分

- description 从 `"表情包发送延迟/秒"` 改为 `"表情包发送固定延迟/秒"`

### 涉及文件

| 文件 | 变更 |
|---|---|
| `_conf_schema.json` | +`meme_send_char_delay`；`meme_send_delay` 描述增加"固定" |
| `core/config/config.py` | +`meme_send_char_delay` 字段 |
| `main.py` | +`meme_send_char_delay` 同步 |
| `core/events/emoji_sender_engine.py` | GIF 联动、按字延迟、空结果守卫 |
| `core/search/emoji_smart_select_service.py` | 调用 `_send_qq_image_as_sticker` 时传 `plugin` |
