### PR TITLE
Fix batch import file picker and drag-and-drop in WebUI

### DIFF
--- a/pages/dashboard/app.css
+++ b/pages/dashboard/app.css
@@ -1090,6 +1090,27 @@ select.codex-input {
     background: rgba(212, 180, 110, 0.05);
 }
 
+.batch-upload-area.is-drag-active {
+    border-color: var(--gold-primary);
+    background: rgba(212, 180, 110, 0.12);
+    box-shadow: 0 0 0 1px rgba(212, 180, 110, 0.25) inset;
+}
+
+.native-file-input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+    opacity: 0;
+    pointer-events: none;
+}
+
 .upload-preview {
     max-width: 200px;
     max-height: 200px;

--- a/pages/dashboard/app.js
+++ b/pages/dashboard/app.js
@@ -192,6 +192,7 @@ createApp({
         const batchUploadOpen = ref(false);
         const batchUploading = ref(false);
         const batchFolderMode = ref(false);
+        const batchDragActive = ref(false);
         const batchFiles = ref([]);
         const batchPreviews = ref([]);
         const batchUploadError = ref(null);
@@ -1071,9 +1072,9 @@ createApp({
 
         const openBatchUploadModal = () => {
             batchUploadOpen.value = true;
-            batchFiles.value = [];
-            batchPreviews.value = [];
+            clearBatchFiles();
             batchUploadError.value = null;
+            batchDragActive.value = false;
             batchTaskId.value = null;
             batchTaskStatus.value = null;
             Object.assign(batchUploadForm, {
@@ -1085,31 +1086,106 @@ createApp({
 
         const closeBatchUploadModal = () => {
             batchUploadOpen.value = false;
+            clearBatchFiles();
+            batchDragActive.value = false;
             if (batchPollInterval) {
                 clearInterval(batchPollInterval);
                 batchPollInterval = null;
             }
         };
 
+        const resetBatchInput = (inputEl) => {
+            if (inputEl) inputEl.value = '';
+        };
+
+        const imageFileExtensions = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp']);
+
+        const isImageFile = (file) => {
+            if (!file) return false;
+
+            const mimeType = String(file.type || '').toLowerCase();
+            if (mimeType.startsWith('image/')) return true;
+
+            const fileName = String(file.name || '').toLowerCase();
+            return Array.from(imageFileExtensions).some((ext) => fileName.endsWith(ext));
+        };
+
+        const normalizeImageFiles = (fileList) => Array.from(fileList || []).filter(isImageFile);
+
+        const setBatchFiles = (files) => {
+            batchPreviews.value.forEach((url) => URL.revokeObjectURL(url));
+            batchFiles.value = files;
+            batchPreviews.value = files.map((file) => URL.createObjectURL(file));
+        };
+
         const clearBatchFiles = () => {
-            batchFiles.value = [];
-            batchPreviews.value.forEach(url => URL.revokeObjectURL(url));
-            batchPreviews.value = [];
+            setBatchFiles([]);
+            resetBatchInput(batchFileInput.value);
+            resetBatchInput(batchFolderInput.value);
         };
 
         const batchFileInput = ref(null);
         const batchFolderInput = ref(null);
+        const openNativeFilePicker = (inputEl) => {
+            if (!inputEl) return;
+            resetBatchInput(inputEl);
+            if (typeof inputEl.showPicker === 'function') {
+                try {
+                    inputEl.showPicker();
+                    return;
+                } catch (e) {
+                    console.warn('showPicker failed, falling back to click():', e);
+                }
+            }
+            inputEl.click();
+        };
         const triggerBatchFileInput = () => {
             const el = batchFolderMode.value ? batchFolderInput.value : batchFileInput.value;
-            if (el) el.click();
+            openNativeFilePicker(el);
         };
 
         const handleBatchFileSelect = (e) => {
-            const files = Array.from(e.target.files).filter(f => f.type.startsWith('image/'));
+            const files = normalizeImageFiles(e.target?.files);
             if (files.length === 0) return;
-            batchPreviews.value.forEach(url => URL.revokeObjectURL(url));
-            batchFiles.value = files;
-            batchPreviews.value = files.map(f => URL.createObjectURL(f));
+            batchUploadError.value = null;
+            setBatchFiles(files);
+            resetBatchInput(e.target);
+        };
+
+        const batchAreaContainsDragTarget = (event) => {
+            const currentTarget = event.currentTarget;
+            const relatedTarget = event.relatedTarget;
+            return Boolean(currentTarget && relatedTarget && currentTarget.contains(relatedTarget));
+        };
+
+        const onBatchDragEnter = (event) => {
+            event.preventDefault();
+            batchDragActive.value = true;
+        };
+
+        const onBatchDragOver = (event) => {
+            event.preventDefault();
+            if (event.dataTransfer) {
+                event.dataTransfer.dropEffect = 'copy';
+            }
+            batchDragActive.value = true;
+        };
+
+        const onBatchDragLeave = (event) => {
+            if (batchAreaContainsDragTarget(event)) return;
+            batchDragActive.value = false;
+        };
+
+        const onBatchDrop = (event) => {
+            event.preventDefault();
+            batchDragActive.value = false;
+            const files = normalizeImageFiles(event.dataTransfer?.files);
+            if (files.length === 0) {
+                batchUploadError.value = t('pages.dashboard.alerts.no_images_dropped', 'No image files were dropped.');
+                return;
+            }
+            batchUploadError.value = null;
+            setBatchFiles(files);
         };
 
         const formatBatchSize = () => {
@@ -1188,8 +1264,8 @@ createApp({
         const resetBatchUpload = () => {
             batchTaskId.value = null;
             batchTaskStatus.value = null;
-            batchFiles.value = [];
-            batchPreviews.value = [];
+            batchDragActive.value = false;
+            clearBatchFiles();
             batchUploadError.value = null;
         };
 
@@ -1569,6 +1645,7 @@ createApp({
             batchUploadOpen,
             batchUploading,
             batchFolderMode,
+            batchDragActive,
             batchFiles,
             batchPreviews,
             batchUploadError,
@@ -1586,6 +1663,10 @@ createApp({
             triggerBatchFileInput,
             clearBatchFiles,
             handleBatchFileSelect,
+            onBatchDragEnter,
+            onBatchDragOver,
+            onBatchDragLeave,
+            onBatchDrop,
             formatBatchSize,
             submitBatchUpload,
             resetBatchUpload,

--- a/pages/dashboard/app.js
+++ b/pages/dashboard/app.js
@@ -1072,7 +1072,8 @@ createApp({
 
         const openBatchUploadModal = () => {
             batchUploadOpen.value = true;
-            clearBatchFiles();
+            batchFiles.value = [];
+            batchPreviews.value = [];
             batchUploadError.value = null;
             batchDragActive.value = false;
             batchTaskId.value = null;
@@ -1086,7 +1087,6 @@ createApp({
 
         const closeBatchUploadModal = () => {
             batchUploadOpen.value = false;
-            clearBatchFiles();
             batchDragActive.value = false;
             if (batchPollInterval) {
                 clearInterval(batchPollInterval);
@@ -1098,19 +1098,9 @@ createApp({
             if (inputEl) inputEl.value = '';
         };
 
-        const imageFileExtensions = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp']);
-
-        const isImageFile = (file) => {
-            if (!file) return false;
-
-            const mimeType = String(file.type || '').toLowerCase();
-            if (mimeType.startsWith('image/')) return true;
-
-            const fileName = String(file.name || '').toLowerCase();
-            return Array.from(imageFileExtensions).some((ext) => fileName.endsWith(ext));
-        };
-
-        const normalizeImageFiles = (fileList) => Array.from(fileList || []).filter(isImageFile);
+        const normalizeImageFiles = (fileList) => Array.from(fileList || []).filter((file) =>
+            file && String(file.type || '').startsWith('image/')
+        );
 
         const setBatchFiles = (files) => {
             batchPreviews.value.forEach((url) => URL.revokeObjectURL(url));

--- a/pages/dashboard/template.js
+++ b/pages/dashboard/template.js
@@ -735,13 +735,19 @@ export const TEMPLATE = `
 
         <form @submit.prevent="submitBatchUpload" style="padding:24px">
             <div v-if="!batchTaskId">
-                <div class="upload-area" @click="triggerBatchFileInput" style="min-height:150px">
+                <div class="upload-area batch-upload-area" :class="{ 'is-drag-active': batchDragActive }"
+                    @click="triggerBatchFileInput"
+                    @dragenter="onBatchDragEnter"
+                    @dragover="onBatchDragOver"
+                    @dragleave="onBatchDragLeave"
+                    @drop="onBatchDrop"
+                    style="min-height:150px">
                     <input v-if="!batchFolderMode" ref="batchFileInput" type="file" accept="image/*" multiple
-                        @change="handleBatchFileSelect" style="display:none">
+                        @change="handleBatchFileSelect" class="native-file-input">
                     <input v-else ref="batchFolderInput" type="file" accept="image/*" webkitdirectory
-                        @change="handleBatchFileSelect" style="display:none">
+                        @change="handleBatchFileSelect" class="native-file-input">
 
-                    <div style="display:flex;align-items:center;gap:6px;margin-bottom:6px">
+                    <div style="display:flex;align-items:center;gap:6px;margin-bottom:6px" @click.stop>
                         <label
                             style="font-size:12px;color:var(--text-muted);cursor:pointer;display:flex;align-items:center;gap:4px">
                             <input type="checkbox" v-model="batchFolderMode" style="accent-color:var(--gold-primary)">


### PR DESCRIPTION
## 问题

WebUI 的批量导入表情包存在两个问题：

1. 点击上传区时，在部分环境下不会稳定弹出文件选择窗口
2. UI 提示支持拖拽上传，但实际没有接入拖拽事件，文件无法拖入上传区

## 修改

- 为批量上传区补充了 `dragenter` / `dragover` / `dragleave` / `drop` 事件绑定
- 调整文件选择器触发方式，优先使用 `showPicker()`，失败时回退到 `click()`
- 将批量上传使用的文件输入从 `display:none` 改为视觉隐藏方案
- 避免点击上传区内部控件时误触发文件选择

## 结果

修复后：

- 批量上传区支持真正的拖拽导入
- 点击上传区的文件选择器触发方式更稳，兼容性更好