### PR TITLE
fix:WebUI大修整

### DIFF
--- a/core/db/database_service.py
+++ b/core/db/database_service.py
@@ -1222,10 +1222,19 @@ class DatabaseService:
                 f"SELECT COUNT(*) as cnt FROM emoji_pending p {where_sql}", params
             ).fetchone()["cnt"]
 
+            category_where_clauses = [
+                clause for clause in where_clauses if clause != "p.category = ?"
+            ]
+            category_params = params[1:] if category else params
+            category_where_sql = (
+                "WHERE " + " AND ".join(category_where_clauses)
+                if category_where_clauses
+                else ""
+            )
             cat_rows = conn.execute(
-                f"SELECT p.category, COUNT(*) as cnt FROM emoji_pending p {where_sql} "
+                f"SELECT p.category, COUNT(*) as cnt FROM emoji_pending p {category_where_sql} "
                 "GROUP BY p.category",
-                params,
+                category_params,
             ).fetchall()
             category_counts = {r["category"]: r["cnt"] for r in cat_rows}
 

--- a/pages/dashboard/app.css
+++ b/pages/dashboard/app.css
@@ -321,7 +321,8 @@ h2 {
 }
 
 .category-count {
-    font-family: 'Cinzel', serif;
+    font-family: inherit;
+    font-variant-numeric: tabular-nums;
     font-size: 0.75rem;
     color: var(--text-secondary);
     background: var(--bg-base);

--- a/pages/dashboard/app.css
+++ b/pages/dashboard/app.css
@@ -475,7 +475,6 @@ h2 {
     position: relative;
     cursor: pointer;
     overflow: hidden;
-    aspect-ratio: 1;
     display: flex;
     flex-direction: column;
     transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
@@ -513,22 +512,29 @@ h2 {
 
 
 .item-image {
-    flex: 1;
+    flex: 0 0 auto;
+    width: 100%;
+    aspect-ratio: 1;
     display: flex;
     align-items: center;
     justify-content: center;
-    padding: 12px;
     overflow: hidden;
     min-height: 0;
 }
 
 .item-image img {
-    max-width: 100%;
-    max-height: 100%;
+    width: 100%;
+    height: 100%;
     object-fit: contain;
     filter: brightness(0.95);
     transition: filter 0.2s, transform 0.2s;
     will-change: transform;
+}
+
+.item-image .image-placeholder {
+    width: 100%;
+    height: 100%;
+    border-radius: 0;
 }
 
 .item-slot:hover .item-image img {
@@ -2260,16 +2266,19 @@ input, select, textarea {
     background: var(--bg-card);
     border-radius: 12px;
     overflow: hidden;
-    aspect-ratio: 1;
+    display: flex;
+    flex-direction: column;
 }
 .skeleton-image {
-    height: 70%;
+    flex: 0 0 auto;
+    width: 100%;
+    aspect-ratio: 1;
     background: linear-gradient(90deg, var(--bg-elevated) 25%, var(--bg-card) 50%, var(--bg-elevated) 75%);
     background-size: 200% 100%;
     animation: shimmer 1.5s infinite;
 }
 .skeleton-text {
-    height: 30%;
+    height: 36px;
     margin: 8px;
     border-radius: 4px;
     background: var(--bg-elevated);

--- a/pages/dashboard/app.css
+++ b/pages/dashboard/app.css
@@ -523,12 +523,13 @@ h2 {
 }
 
 .item-image img {
-    width: 100%;
-    height: 100%;
+    width: auto;
+    height: auto;
+    max-width: 100%;
+    max-height: 100%;
     object-fit: contain;
     filter: brightness(0.95);
-    transition: filter 0.2s, transform 0.2s;
-    will-change: transform;
+    transition: filter 0.2s;
 }
 
 .item-image .image-placeholder {
@@ -539,7 +540,6 @@ h2 {
 
 .item-slot:hover .item-image img {
     filter: brightness(1);
-    transform: scale(1.02);
 }
 
 

--- a/pages/dashboard/app.css
+++ b/pages/dashboard/app.css
@@ -28,7 +28,7 @@
     --slot-size-small: 100px;
     --sidebar-width: 180px;
     --sidebar-expanded: 220px;
-    --header-height: 56px;
+    --header-height: 72px;
 }
 
 [data-theme="light"] {
@@ -191,12 +191,14 @@ h2 {
     padding: 0;
     margin: 0 0 4px 0;
     font-size: 1.4rem;
+    line-height: 1.2;
 }
 
 .header-text p {
     margin: 0;
     color: var(--text-secondary);
     font-size: 0.8rem;
+    line-height: 1.3;
     letter-spacing: 0.15em;
     text-transform: uppercase;
 }
@@ -218,12 +220,14 @@ h2 {
     font-family: 'Cinzel', serif;
     font-size: 1.4rem;
     font-weight: 700;
+    line-height: 1.1;
     color: var(--gold-bright);
     text-shadow: 0 0 10px rgba(212, 180, 110, 0.3);
 }
 
 .stat-label {
     font-size: 0.65rem;
+    line-height: 1.2;
     color: var(--text-secondary);
     text-transform: uppercase;
     letter-spacing: 0.1em;

--- a/pages/dashboard/app.css
+++ b/pages/dashboard/app.css
@@ -2861,6 +2861,7 @@ input, select, textarea {
 .pending-tags {
     grid-row: 3;
     display: flex;
+    align-items: center;
     gap: 4px;
     flex-wrap: wrap;
     overflow: hidden;
@@ -2868,11 +2869,16 @@ input, select, textarea {
 }
 
 .pending-tag {
+    display: inline-flex;
+    align-items: center;
+    height: 20px;
     font-size: 10px !important;
+    line-height: 1;
     padding: 2px 7px !important;
     background: var(--bg-card-hover) !important;
     border: 1px solid var(--glass-border);
     border-radius: 4px;
+    white-space: nowrap;
 }
 
 .pending-actions {

--- a/pages/dashboard/app.css
+++ b/pages/dashboard/app.css
@@ -1337,6 +1337,7 @@ select.codex-input {
 
     .main-container {
         padding-left: 12px;
+        padding-top: 12px;
     }
 
     .inventory-toolbar {
@@ -2541,8 +2542,8 @@ input, select, textarea {
 .section-tab {
     display: flex;
     align-items: center;
-    gap: 10px;
-    padding: 11px 14px;
+    gap: 8px;
+    padding: 11px 8px;
     border-radius: 10px;
     cursor: pointer;
     transition: background 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
@@ -2583,6 +2584,8 @@ input, select, textarea {
     font-size: 13px;
     letter-spacing: 0.03em;
     flex: 1;
+    min-width: 0;
+    white-space: nowrap;
 }
 
 .section-badge {
@@ -2595,6 +2598,7 @@ input, select, textarea {
     min-width: 22px;
     text-align: center;
     line-height: 1.3;
+    flex-shrink: 0;
 }
 
 

--- a/pages/dashboard/app.css
+++ b/pages/dashboard/app.css
@@ -143,6 +143,11 @@ h2 {
     align-items: center;
     gap: 16px;
     flex: 1;
+    padding: 6px 0;
+}
+
+.mobile-menu-button {
+    display: none;
 }
 
 .header-right {
@@ -305,6 +310,10 @@ h2 {
 .category-name {
     color: var(--text-primary);
     font-size: 0.9rem;
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .category-item.active .category-name {
@@ -318,6 +327,9 @@ h2 {
     background: var(--bg-base);
     padding: 2px 8px;
     border: 1px solid var(--glass-border);
+    border-radius: 9999px;
+    margin-left: auto;
+    flex-shrink: 0;
 }
 
 .category-item.active .category-count {
@@ -1301,7 +1313,26 @@ select.codex-input {
     }
     
     .sidebar {
-        display: none;
+        top: 0;
+        bottom: 0;
+        width: min(280px, 84vw);
+        max-width: none;
+        padding: 12px;
+        transform: translateX(-100%);
+        transition: transform 0.2s ease;
+        z-index: 120;
+        box-shadow: 8px 0 28px rgba(0, 0, 0, 0.35);
+    }
+
+    .sidebar.is-open {
+        transform: translateX(0);
+    }
+
+    .mobile-sidebar-backdrop {
+        position: fixed;
+        inset: 0;
+        z-index: 110;
+        background: rgba(0, 0, 0, 0.45);
     }
 
     .main-container {
@@ -2341,6 +2372,27 @@ input, select, textarea {
     .header-title {
         min-width: 0;
         gap: 10px;
+        padding: 4px 0;
+    }
+
+    .mobile-menu-button {
+        width: 36px;
+        height: 36px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        flex: 0 0 36px;
+        padding: 0;
+        color: var(--gold-primary);
+        background: var(--bg-card);
+        border: 1px solid var(--glass-border);
+        border-radius: 8px;
+        cursor: pointer;
+    }
+
+    .mobile-menu-button svg {
+        width: 20px;
+        height: 20px;
     }
 
     .header-text h1 {
@@ -2694,6 +2746,8 @@ input, select, textarea {
 .pending-image {
     width: 140px;
     min-width: 140px;
+    aspect-ratio: 1;
+    align-self: flex-start;
     background: var(--bg-card-hover);
     display: flex;
     align-items: center;
@@ -2706,7 +2760,6 @@ input, select, textarea {
     width: 100%;
     height: 100%;
     object-fit: contain;
-    padding: 8px;
 }
 
 .pending-image .image-placeholder {
@@ -2809,8 +2862,9 @@ input, select, textarea {
 }
 
 .pending-actions {
-    display: flex;
-    gap: 8px;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 6px;
     margin-top: auto;
     padding-top: 6px;
 }
@@ -2830,6 +2884,10 @@ input, select, textarea {
     color: var(--text-secondary);
     white-space: nowrap;
     min-height: 32px;
+    min-width: 0;
+    justify-content: center;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .pending-btn:hover {
@@ -2919,7 +2977,7 @@ input, select, textarea {
     }
 
     .pending-card {
-        height: 110px;
+        min-height: 110px;
     }
 
     .pending-image {
@@ -2958,7 +3016,7 @@ input, select, textarea {
     }
 
     .pending-card {
-        height: 96px;
+        min-height: 96px;
     }
 
     .pending-image {

--- a/pages/dashboard/app.css
+++ b/pages/dashboard/app.css
@@ -2739,6 +2739,7 @@ input, select, textarea {
 
 
 .pending-card {
+    --pending-card-size: 140px;
     display: flex;
     flex-direction: row;
     background: var(--bg-card);
@@ -2748,14 +2749,16 @@ input, select, textarea {
     transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;
     cursor: pointer;
     position: relative;
-    min-height: 140px;
+    height: var(--pending-card-size);
+    min-height: var(--pending-card-size);
 }
 
 .pending-image {
-    width: 140px;
-    min-width: 140px;
+    width: calc(var(--pending-card-size) - 2px);
+    min-width: calc(var(--pending-card-size) - 2px);
+    height: 100%;
     aspect-ratio: 1;
-    align-self: flex-start;
+    align-self: stretch;
     background: var(--bg-card-hover);
     display: flex;
     align-items: center;
@@ -2777,10 +2780,10 @@ input, select, textarea {
 
 .pending-info {
     flex: 1;
-    padding: 14px 16px;
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
+    padding: 10px 12px;
+    display: grid;
+    grid-template-rows: auto minmax(0, 1fr) auto auto;
+    gap: 4px;
     min-width: 0;
     overflow: hidden;
 }
@@ -2819,6 +2822,7 @@ input, select, textarea {
 }
 
 .pending-meta {
+    grid-row: 1;
     display: flex;
     align-items: center;
     gap: 6px;
@@ -2843,10 +2847,11 @@ input, select, textarea {
 }
 
 .pending-desc {
-    font-size: 14px;
+    grid-row: 2;
+    font-size: 13px;
     font-weight: 500;
     color: var(--text-primary);
-    line-height: 1.5;
+    line-height: 1.35;
     overflow: hidden;
     display: -webkit-box;
     -webkit-line-clamp: 2;
@@ -2854,11 +2859,12 @@ input, select, textarea {
 }
 
 .pending-tags {
+    grid-row: 3;
     display: flex;
     gap: 4px;
     flex-wrap: wrap;
     overflow: hidden;
-    max-height: 24px;
+    max-height: 20px;
 }
 
 .pending-tag {
@@ -2870,32 +2876,89 @@ input, select, textarea {
 }
 
 .pending-actions {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-row: 4;
+    display: flex;
+    justify-content: flex-end;
     gap: 6px;
     margin-top: auto;
-    padding-top: 6px;
+    overflow: visible;
 }
 
 .pending-btn {
     display: inline-flex;
     align-items: center;
-    gap: 5px;
-    padding: 5px 12px;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    min-width: 32px;
+    min-height: 32px;
+    flex: 0 0 32px;
+    padding: 0;
     border: 1px solid var(--glass-border);
-    border-radius: 8px;
-    font-size: 12px;
-    font-weight: 600;
+    border-radius: 50%;
     cursor: pointer;
-    transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease;
+    transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease, transform 0.18s ease;
     background: var(--bg-card-hover);
     color: var(--text-secondary);
+    position: relative;
+    overflow: visible;
+}
+
+.pending-btn svg {
+    width: 16px;
+    height: 16px;
+    flex: none;
+}
+
+.pending-btn::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    left: 50%;
+    bottom: calc(100% + 7px);
+    z-index: 5;
+    padding: 5px 8px;
+    border: 1px solid var(--glass-border);
+    border-radius: 6px;
+    background: var(--bg-elevated);
+    color: var(--text-primary);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+    font-size: 11px;
+    font-weight: 500;
+    line-height: 1.2;
     white-space: nowrap;
-    min-height: 32px;
-    min-width: 0;
-    justify-content: center;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    pointer-events: none;
+    opacity: 0;
+    visibility: hidden;
+    transform: translate(-50%, 4px);
+    transition: opacity 0.15s ease, transform 0.15s ease, visibility 0.15s ease;
+}
+
+.pending-btn:last-child::after {
+    right: 0;
+    left: auto;
+    transform: translateY(4px);
+}
+
+@media (hover: hover) {
+    .pending-btn:hover::after {
+        opacity: 1;
+        visibility: visible;
+        transform: translate(-50%, 0);
+    }
+
+    .pending-btn:last-child:hover::after {
+        transform: translateY(0);
+    }
+}
+
+.pending-btn:focus-visible::after {
+    opacity: 1;
+    visibility: visible;
+    transform: translate(-50%, 0);
+}
+
+.pending-btn:last-child:focus-visible::after {
+    transform: translateY(0);
 }
 
 .pending-btn:hover {
@@ -2985,12 +3048,7 @@ input, select, textarea {
     }
 
     .pending-card {
-        min-height: 110px;
-    }
-
-    .pending-image {
-        width: 100px;
-        min-width: 100px;
+        --pending-card-size: 112px;
     }
 
     .pending-info {
@@ -3000,6 +3058,11 @@ input, select, textarea {
 
     .pending-desc {
         font-size: 13px;
+        -webkit-line-clamp: 1;
+    }
+
+    .pending-tags {
+        display: none;
     }
 
     .pending-actions {
@@ -3007,8 +3070,11 @@ input, select, textarea {
     }
 
     .pending-btn {
-        padding: 4px 8px;
-        font-size: 11px;
+        width: 30px;
+        height: 30px;
+        min-width: 30px;
+        min-height: 30px;
+        flex-basis: 30px;
     }
 
     .pending-batch-actions {
@@ -3024,15 +3090,6 @@ input, select, textarea {
     }
 
     .pending-card {
-        min-height: 96px;
-    }
-
-    .pending-image {
-        width: 80px;
-        min-width: 80px;
-    }
-
-    .pending-btn svg {
-        display: none;
+        --pending-card-size: 96px;
     }
 }

--- a/pages/dashboard/app.css
+++ b/pages/dashboard/app.css
@@ -1248,8 +1248,6 @@ select.codex-input {
         padding: 8px 6px;
     }
 
-    .sidebar:hover { width: var(--sidebar-expanded); }
-
     .item-stats {
         width: 100%;
         border-left: none;
@@ -1267,6 +1265,12 @@ select.codex-input {
 
     .item-preview img {
         max-height: 350px;
+    }
+}
+
+@media (hover: hover) and (min-width: 769px) and (max-width: 1024px) {
+    .sidebar:hover {
+        width: var(--sidebar-expanded);
     }
 }
 

--- a/pages/dashboard/app.js
+++ b/pages/dashboard/app.js
@@ -1637,7 +1637,12 @@ createApp({
         let resizeTimer = null;
         const handleResize = () => {
             clearTimeout(resizeTimer);
-            resizeTimer = setTimeout(() => { updatePageSize(); fetchImages(1); }, 300);
+            resizeTimer = setTimeout(() => {
+                updatePageSize();
+                if (activeSection.value === 'library') {
+                    fetchImages(1);
+                }
+            }, 300);
         };
         onMounted(() => {
             updateDocumentMeta();

--- a/pages/dashboard/app.js
+++ b/pages/dashboard/app.js
@@ -1824,6 +1824,7 @@ createApp({
             PLACEHOLDER,
             imageDataUrls,
             originalDataUrls,
+            loadOriginalImage,
             downloadImage,
 
             favoriteCount,

--- a/pages/dashboard/app.js
+++ b/pages/dashboard/app.js
@@ -52,6 +52,7 @@ createApp({
 
         const pendingImages = ref([]);
         const pendingTotal = ref(0);
+        const pendingCategoryTotal = ref(0);
         const pendingCategories = ref([]);
         const pendingStats = reactive({ pending: 0, capacity: 200, paused: false });
         const pendingLoading = ref(false);
@@ -534,9 +535,16 @@ createApp({
                 });
                 const res = await apiFetch('api/pending?' + params.toString());
                 const data = await res.json();
-                if (!data.success) { pendingImages.value = []; pendingTotal.value = 0; return; }
+                if (!data.success) {
+                    pendingImages.value = [];
+                    pendingTotal.value = 0;
+                    pendingCategoryTotal.value = 0;
+                    return;
+                }
                 const nextImages = data.images || [];
                 const nextTotal = Number(data.total || 0);
+                const nextCategories = normalizeCategories(data.categories);
+                const nextCategoryTotal = Number(data.category_total);
                 const lastPage = Math.max(1, Math.ceil(nextTotal / pendingPageSize.value));
                 if (page > lastPage && nextTotal > 0) {
                     pendingFetchLock = false;
@@ -545,7 +553,10 @@ createApp({
                 pendingCurrentPage.value = page;
                 pendingImages.value = nextImages;
                 pendingTotal.value = nextTotal;
-                pendingCategories.value = normalizeCategories(data.categories);
+                pendingCategories.value = nextCategories;
+                pendingCategoryTotal.value = Number.isFinite(nextCategoryTotal)
+                    ? nextCategoryTotal
+                    : nextCategories.reduce((sum, category) => sum + category.count, 0);
                 nextImages.forEach(img => { if (img.hash) loadImageData(img.hash); });
             } catch (e) { console.error(e); }
             finally { pendingLoading.value = false; pendingFetchLock = false; }
@@ -1691,6 +1702,7 @@ createApp({
             total,
             pendingImages,
             pendingTotal,
+            pendingCategoryTotal,
             pendingCategories,
             pendingStats,
             pendingLoading,

--- a/pages/dashboard/app.js
+++ b/pages/dashboard/app.js
@@ -38,6 +38,7 @@ function hashToColor(hash) {
 createApp({
     setup() {
         const activeSection = ref('library');
+        const sidebarOpen = ref(false);
         const images = ref([]);
         const categories = ref([]);
         const stats = reactive({ total: 0, categories: 0, today: 0 });
@@ -293,6 +294,13 @@ createApp({
             return [];
         };
 
+        const getCategoryName = (key) => {
+            const categoryKey = String(key || '').trim();
+            const category = [...categories.value, ...pendingCategories.value]
+                .find((item) => item.key === categoryKey);
+            return category?.name || categoryKey;
+        };
+
         const emotionsOpen = ref(false);
         const newEmotion = reactive({ key: '', name: '', desc: '' });
         const addingEmotion = ref(false);
@@ -475,6 +483,9 @@ createApp({
                 for (const hash of Object.keys(imageDataUrls)) {
                     if (!currentHashes.has(hash)) delete imageDataUrls[hash];
                 }
+                for (const hash of Object.keys(originalDataUrls)) {
+                    if (!currentHashes.has(hash)) delete originalDataUrls[hash];
+                }
                 nextTick(() => observeImages());
                 if (selectedImages.value.size > 0) {
                     const visibleHashes = new Set(nextImages.map((img) => img.hash));
@@ -542,12 +553,25 @@ createApp({
 
         const switchSection = (section) => {
             activeSection.value = section;
+            sidebarOpen.value = false;
             if (section === 'pending') {
                 fetchPendingStats();
                 fetchPendingImages(1);
             } else {
                 fetchImages(1);
             }
+        };
+
+        const selectLibraryCategory = (category) => {
+            selectedCategory.value = category;
+            sidebarOpen.value = false;
+            fetchImages(1);
+        };
+
+        const selectPendingCategory = (category) => {
+            pendingCategory.value = category;
+            sidebarOpen.value = false;
+            fetchPendingImages(1);
         };
 
         const pendingDebouncedSearch = () => {
@@ -1648,6 +1672,7 @@ createApp({
 
         return {
             activeSection,
+            sidebarOpen,
             switchSection,
             images,
             categories,
@@ -1671,6 +1696,9 @@ createApp({
             pendingBatchMode,
             pendingSelectedImages,
             fetchPendingImages,
+            selectLibraryCategory,
+            selectPendingCategory,
+            getCategoryName,
             fetchPendingStats,
             pendingDebouncedSearch,
             approvePending,

--- a/pages/dashboard/template.js
+++ b/pages/dashboard/template.js
@@ -1,6 +1,12 @@
 export const TEMPLATE = `
 <header class="codex-header">
     <div class="header-title">
+        <button class="mobile-menu-button" type="button" @click="sidebarOpen = true"
+            :aria-label="t('pages.dashboard.actions.open_navigation', 'Open navigation')">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" aria-hidden="true">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+        </button>
         <div class="header-icon">
             <svg style="width:28px;height:28px" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"
@@ -37,7 +43,8 @@ export const TEMPLATE = `
 </header>
 
 <div class="main-container">
-    <aside class="sidebar">
+    <div v-if="sidebarOpen" class="mobile-sidebar-backdrop" @click="sidebarOpen = false"></div>
+    <aside class="sidebar" :class="{ 'is-open': sidebarOpen }">
         <div class="section-switcher">
             <div class="section-tab" :class="{ active: activeSection === 'pending' }" @click="switchSection('pending')">
                 <svg class="section-tab-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor">
@@ -61,19 +68,19 @@ export const TEMPLATE = `
             <div class="sidebar-title">{{ t('pages.dashboard.categories.title', 'Categories') }}</div>
             <div class="category-list">
                 <div class="category-item favorite-category" :class="{ active: selectedCategory === '__favorite__' }"
-                    @click="selectedCategory = '__favorite__'; fetchImages(1)">
+                    @click="selectLibraryCategory('__favorite__')">
                     <span class="category-icon">⭐</span>
                     <span class="category-name">{{ t('pages.dashboard.categories.favorites', 'Favorites') }}</span>
                     <span class="category-count">{{ favoriteCount }}</span>
                 </div>
                 <div class="category-item" :class="{ active: selectedCategory === '' }"
-                    @click="selectedCategory = ''; fetchImages(1)">
+                    @click="selectLibraryCategory('')">
                     <span class="category-name">{{ t('pages.dashboard.categories.all', 'All') }}</span>
                     <span class="category-count">{{ stats.total || 0 }}</span>
                 </div>
                 <div v-for="cat in categories" :key="cat.key" class="category-item"
                     :class="{ active: selectedCategory === cat.key }"
-                    @click="selectedCategory = cat.key; fetchImages(1)">
+                    @click="selectLibraryCategory(cat.key)">
                     <span class="category-name">{{ cat.name }}</span>
                     <span class="category-count">{{ cat.count }}</span>
                 </div>
@@ -100,13 +107,13 @@ export const TEMPLATE = `
             <div class="sidebar-title">{{ t('pages.dashboard.pending.category_filter', 'Category Filter') }}</div>
             <div class="category-list">
                 <div class="category-item" :class="{ active: pendingCategory === '' }"
-                    @click="pendingCategory = ''; fetchPendingImages(1)">
+                    @click="selectPendingCategory('')">
                     <span class="category-name">{{ t('pages.dashboard.categories.all', 'All') }}</span>
                     <span class="category-count">{{ pendingTotal }}</span>
                 </div>
                 <div v-for="cat in pendingCategories" :key="cat.key" class="category-item"
                     :class="{ active: pendingCategory === cat.key }"
-                    @click="pendingCategory = cat.key; fetchPendingImages(1)">
+                    @click="selectPendingCategory(cat.key)">
                     <span class="category-name">{{ cat.name }}</span>
                     <span class="category-count">{{ cat.count }}</span>
                 </div>
@@ -229,14 +236,15 @@ export const TEMPLATE = `
                         </svg>
                     </button>
 
-                    <div class="item-image" :data-hash="img.hash">
+                    <div class="item-image" :data-hash="img.hash" @mouseenter="loadOriginalImage(img.hash)">
                         <div v-if="!imageDataUrls[img.hash]" class="image-placeholder"
                             :style="{ backgroundColor: hashToColor(img.hash) }"></div>
-                        <img v-else :src="imageDataUrls[img.hash]" loading="lazy" :alt="img.desc" class="fade-in">
+                        <img v-else :src="originalDataUrls[img.hash] || imageDataUrls[img.hash]" loading="lazy"
+                            :alt="img.desc" class="fade-in">
                     </div>
 
                     <div class="item-info">
-                        <div class="item-category">{{ img.category }}</div>
+                        <div class="item-category">{{ getCategoryName(img.category) }}</div>
                         <div class="item-meta-row">
                             <span class="scope-pill" :class="img.scope_mode === 'local' ? 'local' : 'public'">{{
                                 getScopeLabel(img.scope_mode) }}</span>
@@ -340,15 +348,16 @@ export const TEMPLATE = `
                         </svg>
                     </div>
 
-                    <div class="pending-image">
+                    <div class="pending-image" @mouseenter="loadOriginalImage(item.hash)">
                         <div v-if="!imageDataUrls[item.hash]" class="image-placeholder"
                             :style="{ backgroundColor: hashToColor(item.hash) }"></div>
-                        <img v-else :src="imageDataUrls[item.hash]" loading="lazy" :alt="item.desc" class="fade-in">
+                        <img v-else :src="originalDataUrls[item.hash] || imageDataUrls[item.hash]" loading="lazy"
+                            :alt="item.desc" class="fade-in">
                     </div>
 
                     <div class="pending-info">
                         <div class="pending-meta">
-                            <span class="pending-category-badge">{{ item.category }}</span>
+                            <span class="pending-category-badge">{{ getCategoryName(item.category) }}</span>
                             <span v-if="item.scope_mode === 'local'" class="scope-pill local">{{ t('pages.dashboard.scope.local_short', 'Local') }}</span>
                             <span class="pending-source">{{ item.source === 'auto' ? '🤖' : '👤' }}</span>
                         </div>
@@ -460,7 +469,7 @@ export const TEMPLATE = `
                 <div class="item-stats">
                     <div class="stat-row">
                         <span class="stat-name">{{ t('pages.dashboard.fields.category', 'Category') }}</span>
-                        <span class="stat-value">{{ previewItem?.category }}</span>
+                        <span class="stat-value">{{ getCategoryName(previewItem?.category) }}</span>
                     </div>
                     <div class="stat-row">
                         <span class="stat-name">{{ t('pages.dashboard.fields.scope', 'Scope') }}</span>

--- a/pages/dashboard/template.js
+++ b/pages/dashboard/template.js
@@ -109,7 +109,7 @@ export const TEMPLATE = `
                 <div class="category-item" :class="{ active: pendingCategory === '' }"
                     @click="selectPendingCategory('')">
                     <span class="category-name">{{ t('pages.dashboard.categories.all', 'All') }}</span>
-                    <span class="category-count">{{ pendingTotal }}</span>
+                    <span class="category-count">{{ pendingCategoryTotal }}</span>
                 </div>
                 <div v-for="cat in pendingCategories" :key="cat.key" class="category-item"
                     :class="{ active: pendingCategory === cat.key }"

--- a/pages/dashboard/template.js
+++ b/pages/dashboard/template.js
@@ -366,41 +366,41 @@ export const TEMPLATE = `
                             <span v-for="tag in item.tags" :key="tag" class="tag pending-tag">{{ tag }}</span>
                         </div>
                         <div class="pending-actions" v-if="!pendingBatchMode">
-                            <button @click.stop="approvePending(item.id)" class="pending-btn approve-btn"
-                                :title="t('pages.dashboard.actions.approve', 'Approve')">
-                                <svg style="width:14px;height:14px" fill="none" stroke="currentColor"
-                                    viewBox="0 0 24 24">
+                            <button type="button" @click.stop="approvePending(item.id)"
+                                class="pending-btn approve-btn"
+                                :aria-label="t('pages.dashboard.actions.approve', 'Approve')"
+                                :data-tooltip="t('pages.dashboard.actions.approve', 'Approve')">
+                                <svg aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2.5"
                                         d="M5 13l4 4L19 7" />
                                 </svg>
-                                {{ t('pages.dashboard.actions.approve', 'Approve') }}
                             </button>
-                            <button @click.stop="openPendingEdit(item)" class="pending-btn edit-btn"
-                                :title="t('pages.dashboard.actions.edit_approve', 'Edit & approve')">
-                                <svg style="width:14px;height:14px" fill="none" stroke="currentColor"
-                                    viewBox="0 0 24 24">
+                            <button type="button" @click.stop="openPendingEdit(item)"
+                                class="pending-btn edit-btn"
+                                :aria-label="t('pages.dashboard.actions.edit_approve', 'Edit & approve')"
+                                :data-tooltip="t('pages.dashboard.actions.edit_approve', 'Edit & approve')">
+                                <svg aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                                         d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z" />
                                 </svg>
-                                {{ t('pages.dashboard.actions.edit', 'Edit') }}
                             </button>
-                            <button @click.stop="rejectPending(item.id)" class="pending-btn reject-btn"
-                                :title="t('pages.dashboard.actions.delete', 'Delete')">
-                                <svg style="width:14px;height:14px" fill="none" stroke="currentColor"
-                                    viewBox="0 0 24 24">
+                            <button type="button" @click.stop="rejectPending(item.id)"
+                                class="pending-btn reject-btn"
+                                :aria-label="t('pages.dashboard.actions.delete', 'Delete')"
+                                :data-tooltip="t('pages.dashboard.actions.delete', 'Delete')">
+                                <svg aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                                         d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
                                 </svg>
-                                {{ t('pages.dashboard.actions.delete', 'Delete') }}
                             </button>
-                            <button @click.stop="rejectPending(item.id, true)" class="pending-btn reject-bl-btn"
-                                :title="t('pages.dashboard.actions.blacklist', 'Blacklist')">
-                                <svg style="width:14px;height:14px" fill="none" stroke="currentColor"
-                                    viewBox="0 0 24 24">
+                            <button type="button" @click.stop="rejectPending(item.id, true)"
+                                class="pending-btn reject-bl-btn"
+                                :aria-label="t('pages.dashboard.actions.blacklist', 'Blacklist')"
+                                :data-tooltip="t('pages.dashboard.actions.blacklist', 'Blacklist')">
+                                <svg aria-hidden="true" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                                         d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
                                 </svg>
-                                {{ t('pages.dashboard.actions.blacklist', 'Blacklist') }}
                             </button>
                         </div>
                     </div>

--- a/plugin_api.py
+++ b/plugin_api.py
@@ -752,7 +752,15 @@ class PluginAPI:
         try:
             db = self._db
             if not db or not hasattr(db, "get_pending_paginated"):
-                return jsonify({"success": True, "images": [], "total": 0, "categories": {}})
+                return jsonify(
+                    {
+                        "success": True,
+                        "images": [],
+                        "total": 0,
+                        "category_total": 0,
+                        "categories": {},
+                    }
+                )
 
             page = request.args.get("page", 1, type=int)
             page_size = request.args.get("size", 50, type=int)
@@ -771,6 +779,7 @@ class PluginAPI:
                     "success": True,
                     "images": images,
                     "total": total,
+                    "category_total": sum(int(count) for count in cat_counts.values()),
                     "categories": self._build_categories_list(cat_counts),
                 }
             )

--- a/plugin_api.py
+++ b/plugin_api.py
@@ -519,15 +519,28 @@ class PluginAPI:
         image_hash = request.args.get("hash", "").strip()
         if not image_hash:
             return jsonify({"success": False, "error": "缺少 hash"})
+        file_path = None
         for path_str, meta in self._get_index().items():
             if isinstance(meta, dict) and meta.get("hash") == image_hash:
-                if os.path.isfile(path_str):
-                    try:
-                        data_url = self._file_base64(path_str)
-                        return jsonify({"success": True, "hash": image_hash, "url": data_url})
-                    except Exception as e:
-                        logger.warning(f"读取图片失败: {e}")
+                file_path = path_str
                 break
+
+        if not file_path:
+            db = self._db
+            if db and hasattr(db, "get_pending_by_hash"):
+                try:
+                    pending_row = db.get_pending_by_hash(image_hash)
+                except Exception:
+                    pending_row = None
+                if pending_row:
+                    file_path = pending_row.get("path")
+
+        if file_path and os.path.isfile(file_path):
+            try:
+                data_url = self._file_base64(file_path)
+                return jsonify({"success": True, "hash": image_hash, "url": data_url})
+            except Exception as e:
+                logger.warning(f"读取图片失败: {e}")
         return jsonify({"success": False, "error": "图片未找到"})
 
     async def _get_or_create_thumbnail(
@@ -758,7 +771,7 @@ class PluginAPI:
                     "success": True,
                     "images": images,
                     "total": total,
-                    "categories": cat_counts,
+                    "categories": self._build_categories_list(cat_counts),
                 }
             )
         except Exception as e:


### PR DESCRIPTION
修复/更新了：

1. 图片都不能动，改成鼠标hover上去加载原图
2. 缩放窗口图片会消失
3. 审核区卡片中的四个按钮经常因为窗口尺寸问题被盖住
4. 优化图片显示尺寸
5. Logo上下贴边了，视觉效果不好
6. 小窗口/手机上sidebar直接不显示了，导致没法选择审核区和库，给顶栏加左侧加了一个汉堡按钮
7. 审核区sidebar点了某个分类后其他分类就消失了，得重新点“全部”才能显示其他分类
8. 分类有名称，但是只有表情包库的sidebar用了名称，其他地方都用的标识，现在统一用名称了
9. sidebar审核区tab右边的数量气泡会把审核区三个字挤换行
10. sidebar分类筛选下每个分类右边的数字宽是直角，但页面中其他类似元素都是圆角

Before：
<img width="771" height="484" alt="1c75f3c2513b5d1f4584ebef0b8380e1" src="https://github.com/user-attachments/assets/6cec2fb0-b491-473d-8938-39e0b8f3e865" />

After：
<img width="771" height="484" alt="snipaste_20260724_025446" src="https://github.com/user-attachments/assets/246bf617-e4e4-47e1-8eef-2cdde22c0be6" />

