### PR TITLE
feat: make automatic meme stealing non-blocking

### DIFF
--- a/core/events/background_steal_queue.py
+++ b/core/events/background_steal_queue.py
@@ -1,0 +1,256 @@
+"""Bounded background pipeline for passive meme stealing."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from astrbot.api import logger
+
+from ..util.safe_io import safe_remove_file
+
+
+@dataclass(slots=True)
+class StealJob:
+    """A serializable processing job; event objects never cross this boundary."""
+
+    file_path: str
+    extra_meta: dict[str, Any] = field(default_factory=dict)
+    to_pending: bool = True
+    source: str = "automatic"
+
+
+class BackgroundStealQueue:
+    """Bounded queue and workers for downloaded/staged meme files."""
+
+    def __init__(self, plugin: Any, *, capacity: int = 32, worker_count: int = 2):
+        self.plugin = plugin
+        self.capacity = max(1, int(capacity))
+        self.worker_count = max(1, int(worker_count))
+        base_dir = getattr(plugin, "base_dir", None)
+        self.staging_dir = Path(base_dir or Path.cwd()) / "staging"
+        self._queue: asyncio.Queue[StealJob] = asyncio.Queue(maxsize=self.capacity)
+        self._workers: list[asyncio.Task[Any]] = []
+        self._capture_tasks: set[asyncio.Task[Any]] = set()
+        self._save_lock = asyncio.Lock()
+        self._accepting = False
+
+    @property
+    def pending_count(self) -> int:
+        return self._queue.qsize()
+
+    async def start(self) -> None:
+        if self._accepting:
+            return
+        self.staging_dir.mkdir(parents=True, exist_ok=True)
+        self._accepting = True
+        self._workers = [
+            asyncio.create_task(self._worker_loop(), name=f"steal_worker_{i}")
+            for i in range(self.worker_count)
+        ]
+        logger.info(
+            f"[Stealer] 后台偷图队列已启动: capacity={self.capacity}, workers={self.worker_count}"
+        )
+
+    async def stop(self) -> None:
+        self._accepting = False
+        for task in list(self._capture_tasks):
+            if not task.done():
+                task.cancel()
+        if self._capture_tasks:
+            await asyncio.gather(*self._capture_tasks, return_exceptions=True)
+        self._capture_tasks.clear()
+
+        for task in self._workers:
+            if not task.done():
+                task.cancel()
+        if self._workers:
+            await asyncio.gather(*self._workers, return_exceptions=True)
+        self._workers.clear()
+
+        while not self._queue.empty():
+            try:
+                job = self._queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+            await safe_remove_file(job.file_path)
+            self._queue.task_done()
+
+        if self.staging_dir.exists():
+            for path in self.staging_dir.iterdir():
+                if path.is_file():
+                    await safe_remove_file(str(path))
+        logger.info("[Stealer] 后台偷图队列已停止，暂存文件已清理")
+
+    def submit_capture(self, descriptors: list[dict[str, Any]]) -> bool:
+        """Schedule staging/download work and return without waiting for it."""
+        if not self._accepting or not descriptors:
+            return False
+        task = asyncio.create_task(
+            self._stage_and_enqueue(descriptors), name="steal_stage_enqueue"
+        )
+        self._capture_tasks.add(task)
+        task.add_done_callback(self._capture_done)
+        return True
+
+    async def submit_capture_async(self, descriptors: list[dict[str, Any]]) -> bool:
+        """Snapshot local media before the originating event is released.
+
+        AstrBot owns local media paths only for the lifetime of the event. Local
+        files are copied into plugin staging here; remote URLs remain detached
+        background downloads so network latency never reaches the event handler.
+        """
+        if not self._accepting or not descriptors:
+            return False
+        local_descriptors: list[dict[str, Any]] = []
+        remote_descriptors: list[dict[str, Any]] = []
+        for descriptor in descriptors:
+            ref = str(descriptor.get("media_ref") or "")
+            if ref.startswith(("http://", "https://")):
+                remote_descriptors.append(descriptor)
+            else:
+                local_descriptors.append(descriptor)
+
+        accepted = False
+        for descriptor in local_descriptors:
+            staged = await self._stage_local_descriptor(descriptor)
+            if staged:
+                accepted = True
+        if remote_descriptors:
+            accepted = self.submit_capture(remote_descriptors) or accepted
+        return accepted
+
+    async def _stage_local_descriptor(self, descriptor: dict[str, Any]) -> bool:
+        if not self._accepting:
+            return False
+        ref = str(descriptor.get("media_ref") or "")
+        staged_path = ""
+        try:
+            if not ref or not os.path.exists(ref):
+                logger.warning(f"后台偷图暂存失败：媒体不存在 ref={ref[:120]}")
+                return False
+            suffix = Path(ref).suffix or ".jpg"
+            staged = self.staging_dir / f"{uuid.uuid4().hex}{suffix.lower()}"
+            await asyncio.to_thread(shutil.copy2, ref, staged)
+            staged_path = str(staged)
+            job = StealJob(
+                file_path=staged_path,
+                extra_meta=dict(descriptor.get("extra_meta") or {}),
+                to_pending=bool(descriptor.get("to_pending", True)),
+                source=str(descriptor.get("source") or "automatic"),
+            )
+            if self._queue.full():
+                await safe_remove_file(staged_path)
+                logger.warning(
+                    "[Stealer] 后台偷图队列已满，丢弃最新任务 "
+                    f"source={job.source} meta={job.extra_meta}"
+                )
+                return False
+            self._queue.put_nowait(job)
+            logger.info(
+                f"[Stealer] 后台偷图已入队 source={job.source}, queued={self._queue.qsize()}"
+            )
+            return True
+        except Exception as exc:
+            logger.error(f"后台偷图本地暂存失败 ref={ref[:120]}: {exc!r}", exc_info=exc)
+            if staged_path:
+                await safe_remove_file(staged_path)
+            return False
+
+    def _capture_done(self, task: asyncio.Task[Any]) -> None:
+        self._capture_tasks.discard(task)
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.error(f"后台偷图暂存任务异常: {exc!r}", exc_info=exc)
+
+    async def _stage_and_enqueue(self, descriptors: list[dict[str, Any]]) -> None:
+        handler = getattr(self.plugin, "event_handler", None)
+        if handler is None:
+            return
+        for descriptor in descriptors:
+            if not self._accepting:
+                return
+            source_path = ""
+            source_is_temp = False
+            try:
+                ref = str(descriptor.get("media_ref") or "")
+                if ref.startswith(("http://", "https://")):
+                    source_path, _ = await handler._download_url_to_temp(ref)
+                    source_is_temp = True
+                elif ref and os.path.exists(ref):
+                    source_path = ref
+                if not source_path or not os.path.exists(source_path):
+                    logger.warning(f"后台偷图暂存失败：媒体不存在 ref={ref[:120]}")
+                    continue
+
+                suffix = Path(source_path).suffix or ".jpg"
+                staged_path = self.staging_dir / f"{uuid.uuid4().hex}{suffix.lower()}"
+                await asyncio.to_thread(shutil.copy2, source_path, staged_path)
+                if source_is_temp:
+                    await safe_remove_file(source_path)
+
+                job = StealJob(
+                    file_path=str(staged_path),
+                    extra_meta=dict(descriptor.get("extra_meta") or {}),
+                    to_pending=bool(descriptor.get("to_pending", True)),
+                    source=str(descriptor.get("source") or "automatic"),
+                )
+                if self._queue.full():
+                    await safe_remove_file(job.file_path)
+                    logger.warning(
+                        "[Stealer] 后台偷图队列已满，丢弃最新任务 "
+                        f"source={job.source} meta={job.extra_meta}"
+                    )
+                    continue
+                self._queue.put_nowait(job)
+                logger.info(
+                    f"[Stealer] 后台偷图已入队 source={job.source}, queued={self._queue.qsize()}"
+                )
+            except asyncio.CancelledError:
+                if source_is_temp and source_path:
+                    await safe_remove_file(source_path)
+                raise
+            except Exception as exc:
+                logger.error(f"后台偷图暂存失败: {exc!r}", exc_info=exc)
+                if source_is_temp and source_path:
+                    await safe_remove_file(source_path)
+
+    async def _worker_loop(self) -> None:
+        while True:
+            job = await self._queue.get()
+            try:
+                success, index = await self.plugin._process_image(
+                    None,
+                    job.file_path,
+                    is_temp=True,
+                    is_platform_emoji=True,
+                    extra_meta=job.extra_meta,
+                    to_pending=job.to_pending,
+                )
+                logger.info(
+                    f"[Stealer] 后台偷图处理完成 source={job.source}, "
+                    f"success={success}, pending={job.to_pending}"
+                )
+                if success and isinstance(index, dict) and not job.to_pending:
+                    async with self._save_lock:
+                        current = await self.plugin.index_manager.load_index()
+                        current = dict(current or {})
+                        current.update(index)
+                        await self.plugin.index_manager.save_index(current)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.error(
+                    f"后台偷图任务失败 source={job.source} meta={job.extra_meta}: {exc!r}",
+                    exc_info=exc,
+                )
+            finally:
+                await safe_remove_file(job.file_path)
+                self._queue.task_done()

--- a/core/events/event_handler.py
+++ b/core/events/event_handler.py
@@ -10,6 +10,7 @@ from astrbot.api.event import AstrMessageEvent, MessageChain
 from astrbot.api.message_components import Image, Plain
 
 from ..util.safe_io import safe_remove_file
+from .background_steal_queue import BackgroundStealQueue
 from .platform_detector import PlatformDetector
 from .image_download_service import ImageDownloadService
 
@@ -41,6 +42,21 @@ class EventHandler:
         # 子服务
         self._platform_detector = PlatformDetector(plugin_instance)
         self._image_download_service = ImageDownloadService(plugin_instance)
+        self._background_queue: BackgroundStealQueue | None = None
+
+    async def start_background_workers(self) -> None:
+        """Start the bounded passive-steal pipeline."""
+        if self._background_queue is None:
+            self._background_queue = BackgroundStealQueue(
+                self.plugin, capacity=32, worker_count=2
+            )
+        await self._background_queue.start()
+
+    async def stop_background_workers(self) -> None:
+        queue = self._background_queue
+        self._background_queue = None
+        if queue is not None:
+            await queue.stop()
 
     # ===== 门面委托：子服务方法 =====
 
@@ -436,6 +452,15 @@ class EventHandler:
         with self._force_capture_lock:
             self._force_capture_windows.pop(key, None)
 
+    @staticmethod
+    def _get_media_ref(img: Image) -> str:
+        """Extract a plain local path or URL from an image component."""
+        for attr in ("path", "file", "url"):
+            value = getattr(img, attr, "") or ""
+            if value:
+                return str(value)
+        return ""
+
     async def on_message(self, event: AstrMessageEvent):
         """消息监听：偷取消息中的图片并分类存储。"""
         if self._cleaned or self.plugin is None:
@@ -466,9 +491,41 @@ class EventHandler:
         if not imgs and not store_urls:
             return
         if force_active:
+            if self._background_queue is not None:
+                descriptors: list[dict[str, Any]] = []
+                if imgs:
+                    ref = self._get_media_ref(imgs[0])
+                    if ref:
+                        descriptors.append(
+                            {
+                                "media_ref": ref,
+                                "source": "force",
+                                "to_pending": False,
+                                "extra_meta": {},
+                            }
+                        )
+                elif store_urls:
+                    descriptors.append(
+                        {
+                            "media_ref": store_urls[0],
+                            "source": "force",
+                            "to_pending": False,
+                            "extra_meta": {
+                                "source": "qq_store",
+                                "origin_url": self._normalize_str(store_urls[0]),
+                            },
+                        }
+                    )
+                self.consume_force_capture(event)
+                if descriptors and await self._background_queue.submit_capture_async(descriptors):
+                    try:
+                        await event.send(
+                            MessageChain([Plain(text="✅ 已加入后台收录队列，处理完成后自动入库")])
+                        )
+                    except Exception as exc:
+                        logger.debug(f"发送后台收录确认失败: {exc}")
+                return
             await self._handle_force_capture(event, plugin_instance, imgs, store_urls)
-            return
-        if not self._should_process_image():
             return
         # 待审核池容量护栏：池满则暂停自动偷取（不下载、不处理、不删库内文件），
         # 审核通过/删除使 pending 减少后下条消息自然恢复。
@@ -566,6 +623,41 @@ class EventHandler:
                 imgs_to_process.append((i, img, extra_meta or {}))
             except Exception as e:
                 logger.error(f"收集图片信息失败: {e}")
+
+        # 冷却只针对确认过的表情包生效。普通图片不能消耗冷却窗口，
+        # 否则紧随其后的真实表情包会被直接跳过。
+        if (imgs_to_process or store_urls) and not self._should_process_image():
+            return
+
+        if self._background_queue is not None:
+            descriptors: list[dict[str, Any]] = []
+            for _i, img, extra_meta in imgs_to_process:
+                ref = self._get_media_ref(img)
+                if ref:
+                    descriptors.append(
+                        {
+                            "media_ref": ref,
+                            "source": "automatic",
+                            "to_pending": to_pending,
+                            "extra_meta": extra_meta,
+                        }
+                    )
+            for url in store_urls[:3]:
+                extra_meta = {"source": "qq_store", "origin_url": self._normalize_str(url)}
+                if origin_target_str:
+                    extra_meta["origin_target"] = origin_target_str
+                descriptors.append(
+                    {
+                        "media_ref": url,
+                        "source": "automatic",
+                        "to_pending": to_pending,
+                        "extra_meta": extra_meta,
+                    }
+                )
+            if descriptors:
+                await self._background_queue.submit_capture_async(descriptors)
+            return
+
         if imgs_to_process:
             logger.debug(f"开始并行下载 {len(imgs_to_process)} 张图片")
             download_results = await asyncio.gather(
@@ -720,6 +812,7 @@ class EventHandler:
 
     async def cleanup_async(self) -> None:
         """异步清理资源。"""
+        await self.stop_background_workers()
         await self.close_aiohttp_session()
 
     def cleanup(self):

--- a/main.py
+++ b/main.py
@@ -1340,9 +1340,9 @@ class Main(Star):
                     if aiofiles:
                         async with aiofiles.open(prompts_path, encoding="utf-8") as f:
                             content = await f.read()
-                        prompts = json.loads(content)
+                        prompts = json.loads(content.lstrip("\ufeff"))
                     else:
-                        with open(prompts_path, encoding="utf-8") as f:
+                        with open(prompts_path, encoding="utf-8-sig") as f:
                             prompts = json.load(f)
                     self._apply_prompts(prompts)
                     self._ensure_default_prompts_in_config(prompts)
@@ -1354,6 +1354,7 @@ class Main(Star):
             self._sync_image_processor_from_runtime()
             self._sync_similarity_weights()  # 启动时把持久化的文字距离权重同步到 text_similarity 模块
             self.maintenance.start_periodic_tasks()
+            await self.event_handler.start_background_workers()
 
             # 初始化嵌入向量服务 + 回填旧数据（仅在开启嵌入检索时）
             if self.plugin_config.enable_embedding_search:
@@ -1412,6 +1413,10 @@ class Main(Star):
             except Exception:
                 pass
         if self.event_handler:
+            try:
+                await self.event_handler.stop_background_workers()
+            except Exception:
+                pass
             try:
                 await self.event_handler.cleanup_async()
             except Exception:

--- a/tests/test_background_steal_queue.py
+++ b/tests/test_background_steal_queue.py
@@ -1,0 +1,162 @@
+import asyncio
+import tempfile
+import types
+import unittest
+from pathlib import Path
+
+from astrbot_plugin_stealer.core.events.background_steal_queue import (
+    BackgroundStealQueue,
+)
+
+
+class BackgroundQueueTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.processed = []
+        self.saved = []
+        self.plugin = types.SimpleNamespace()
+        self.plugin.base_dir = Path(self.temp_dir.name)
+        self.plugin.index_manager = types.SimpleNamespace(
+            load_index=self._load_index,
+            save_index=self._save_index,
+        )
+
+        async def _process_image(
+            _event,
+            file_path,
+            is_temp=True,
+            is_platform_emoji=True,
+            extra_meta=None,
+            to_pending=True,
+        ):
+            self.processed.append(
+                {
+                    "event": _event,
+                    "file_path": file_path,
+                    "to_pending": to_pending,
+                    "extra_meta": dict(extra_meta or {}),
+                }
+            )
+            return True, {"processed.png": {"category": "happy"}}
+
+        self.plugin._process_image = _process_image
+        self.queue = BackgroundStealQueue(self.plugin, capacity=2, worker_count=1)
+        await self.queue.start()
+
+    async def asyncTearDown(self):
+        await self.queue.stop()
+        self.temp_dir.cleanup()
+
+    async def _load_index(self):
+        return {}
+
+    async def _save_index(self, index):
+        self.saved.append(dict(index))
+
+    def _write_file(self, name="source.jpg"):
+        path = Path(self.temp_dir.name) / name
+        path.write_bytes(b"fixture")
+        return path
+
+    async def test_capture_returns_before_worker_finishes_and_cleans_file(self):
+        source = self._write_file()
+        self.plugin.event_handler = types.SimpleNamespace()
+        self.plugin.event_handler._download_url_to_temp = self._download_url_to_temp
+        self.queue.submit_capture(
+            [
+                {
+                    "media_ref": str(source),
+                    "source": "automatic",
+                    "to_pending": True,
+                    "extra_meta": {"origin_target": "group:242352408"},
+                }
+            ]
+        )
+        await asyncio.sleep(0)
+        self.assertEqual(self.processed, [])
+        for _ in range(20):
+            if self.processed:
+                break
+            await asyncio.sleep(0.01)
+        self.assertEqual(len(self.processed), 1)
+        self.assertIsNone(self.processed[0]["event"])
+        self.assertEqual(self.processed[0]["extra_meta"]["origin_target"], "group:242352408")
+        self.assertFalse(Path(self.processed[0]["file_path"]).exists())
+
+    async def test_local_media_is_snapshotted_before_event_release(self):
+        source = self._write_file("event-owned.gif")
+        self.plugin.event_handler = types.SimpleNamespace(
+            _download_url_to_temp=self._download_url_to_temp
+        )
+        accepted = await self.queue.submit_capture_async(
+            [
+                {
+                    "media_ref": str(source),
+                    "source": "automatic",
+                    "to_pending": True,
+                    "extra_meta": {},
+                }
+            ]
+        )
+        source.unlink()
+        self.assertTrue(accepted)
+        for _ in range(20):
+            if self.processed:
+                break
+            await asyncio.sleep(0.01)
+        self.assertEqual(len(self.processed), 1)
+        self.assertFalse(Path(self.processed[0]["file_path"]).exists())
+
+    async def _download_url_to_temp(self, _url):
+        return None, False
+
+    async def test_shutdown_cleans_pending_staging_files(self):
+        self.queue._queue.put_nowait(
+            types.SimpleNamespace(
+                file_path=str(self._write_file("queued.jpg")),
+            )
+        )
+        await self.queue.stop()
+        self.assertFalse(Path(self.temp_dir.name, "queued.jpg").exists())
+
+    async def test_non_pending_result_is_saved(self):
+        source = self._write_file("direct.jpg")
+        self.plugin.event_handler = types.SimpleNamespace(
+            _download_url_to_temp=self._download_url_to_temp
+        )
+        self.queue.submit_capture(
+            [
+                {
+                    "media_ref": str(source),
+                    "source": "force",
+                    "to_pending": False,
+                    "extra_meta": {},
+                }
+            ]
+        )
+        for _ in range(20):
+            if self.saved:
+                break
+            await asyncio.sleep(0.01)
+        self.assertEqual(self.saved, [{"processed.png": {"category": "happy"}}])
+
+    async def test_full_queue_drops_newest_staged_file(self):
+        for worker in self.queue._workers:
+            worker.cancel()
+        await asyncio.gather(*self.queue._workers, return_exceptions=True)
+        self.queue._workers.clear()
+        self.plugin.event_handler = types.SimpleNamespace(
+            _download_url_to_temp=self._download_url_to_temp
+        )
+        first = self._write_file("first.jpg")
+        second = self._write_file("second.jpg")
+        self.queue.capacity = 1
+        self.queue._queue = asyncio.Queue(maxsize=1)
+        await self.queue._stage_and_enqueue(
+            [
+                {"media_ref": str(first), "source": "automatic"},
+                {"media_ref": str(second), "source": "automatic"},
+            ]
+        )
+        self.assertEqual(self.queue.pending_count, 1)
+        self.assertEqual(len(list(self.queue.staging_dir.iterdir())), 1)

--- a/tests/test_scope_feature.py
+++ b/tests/test_scope_feature.py
@@ -306,6 +306,19 @@ class ScopeFeatureTests(unittest.IsolatedAsyncioTestCase):
             plugin.process_calls[0]["extra_meta"].get("origin_target"), "group:123"
         )
 
+    async def test_non_emoji_image_does_not_consume_steal_cooldown(self):
+        plugin = DummyPlugin()
+        handler = self._create_handler(plugin)
+        image_cls = self._get_shared_image_class()
+        event = DummyEvent(target="group:123", messages=[image_cls()])
+        checks = []
+        handler._should_process_image = lambda: checks.append(True) or True
+        handler._check_platform_emoji_metadata = lambda *args, **kwargs: False
+
+        await handler.on_message(event)
+
+        self.assertEqual(checks, [])
+
     async def test_event_handler_merges_multi_image_results_before_save(self):
         class MultiImagePlugin(DummyPlugin):
             def __init__(self):


### PR DESCRIPTION
## Summary

Passive meme stealing currently keeps the AstrBot event handler busy while it downloads media, runs image processing, and writes the result. Under slow network or VLM conditions this delays unrelated conversation messages.

This PR adds a bounded background pipeline so automatic stealing can continue independently from foreground message handling.

## Changes

- Add a 32-slot queue with two workers for passive and forced captures.
- Copy local AstrBot-owned media into plugin staging before the event is released.
- Download remote media in detached capture tasks.
- Keep `steal_meme` LLM tool handling synchronous for callers that explicitly request it.
- Make `/meme 偷` enqueue capture work and return an acknowledgement promptly.
- Apply cooldown after platform emoji qualification, so ordinary images do not consume the steal window.
- Clean up workers, queued jobs, and staging files during plugin shutdown.
- Preserve metadata such as `origin_target` and existing pending/direct-save behavior.
- Load BOM-prefixed `prompts.json` files correctly.

## Compatibility

Existing configuration keys, processing result schemas, pending-pool behavior, and synchronous LLM tool semantics are preserved.

## Verification

- Test suite: `202 passed in 5.43s`
- Real group verification after the change:
  - `后台偷图已入队 source=automatic`
  - `后台偷图处理完成 source=automatic, success=True, pending=True`
  - resulting GIF was stored with `origin_target: group:242352408`

## Test Coverage

Added queue tests for event detachment, local-media snapshotting, queue overflow cleanup, shutdown cleanup, and direct-save results. Added a regression test for cooldown handling on ordinary images.