### PR TITLE
fix(webui): 导出 formatBytes/formatAddMethod 修复新图点开预览崩溃

### DIFF
--- a/pages/dashboard/app.js
+++ b/pages/dashboard/app.js
@@ -1851,6 +1851,8 @@ createApp({
             nextPage,
             refreshView,
             formatDate,
+            formatBytes,
+            formatAddMethod,
             formatOriginTarget,
             getScopeLabel,
             PLACEHOLDER,


### PR DESCRIPTION
## 问题
新上传的图片（带完整元数据：宽高/格式/字节数）在预览弹窗点开会直接崩，弹窗打不开。

## 原因
app.js 的 setup return 里漏导出了两个函数 `formatBytes` 和 `formatAddMethod`（定义在 1637/1646 行），Vue 模板一调用就报 `formatBytes is not a function`，整个组件抛错。

## 改动
在 setup return 补上这两行：
```
formatBytes,
formatAddMethod,
```

## 验证
- 旧图无元数据字段，那段渲染是假的，不触发；新图字段齐全一触发就崩，与现象吻合。
- 未动后端与数据库，纯前端导出补齐。
